### PR TITLE
monsoon: properly initate Redis DB connection

### DIFF
--- a/src/sonic_exporter/exporter.py
+++ b/src/sonic_exporter/exporter.py
@@ -207,8 +207,7 @@ class SONiCCollector(object):
             self.vtysh = VtySH()
             self.sys_class_net = SystemClassNetworkInfo()
             self.sys_class_hwmon = SystemClassHWMon()
-            secret = subprocess.getoutput("cat /run/redis/auth/passwd")
-            self.sonic_db = swsssdk.SonicV2Connector(password=secret)
+            self.sonic_db = swsssdk.SonicV2Connector()
             self.ntpq = NTPQ()
 
         self.sonic_db.connect(self.sonic_db.COUNTERS_DB)


### PR DESCRIPTION
sonic-exporter fails to connect to REDIS instance with
`[2023-06-19 11:44:48,477][WARNING][interface.py:206] Connecting to DB '2 COUNTERS_DB' failed, will retry in 10s` error.
This happens because SONiC uses passwordless Redis and `SonicV2Connector()` does not support credentials.

